### PR TITLE
Change choice of tarball/zip to be based on extension instead of OS.

### DIFF
--- a/build/package/Archive.targets
+++ b/build/package/Archive.targets
@@ -17,14 +17,14 @@
     </PropertyGroup>
 
     <ZipFileCreateFromDirectory
-        Condition=" '$(OSName)' == 'win' "
+        Condition=" $(GenerateArchivesDestinationArchive.EndsWith('.zip')) "
         SourceDirectory="%(GenerateArchivesInputsOutputs.InputDirectory)"
         DestinationArchive="$(GenerateArchivesDestinationArchive)"
         OverwriteDestination="true"
         ExcludePatterns="%(GenerateArchivesInputsOutputs.ExcludePatterns)" />
 
     <TarGzFileCreateFromDirectory
-        Condition=" '$(OSName)' != 'win' "
+        Condition=" $(GenerateArchivesDestinationArchive.EndsWith('.tar.gz')) "
         SourceDirectory="%(GenerateArchivesInputsOutputs.InputDirectory)"
         DestinationArchive="$(GenerateArchivesDestinationArchive)"
         OverwriteDestination="true"


### PR DESCRIPTION
Previously, Linux machines would produce a tarball but with a .zip
extension, which confused some downstream repos which use the extension
to determine how to extract them.

Fixes #11.
