### PR TITLE
Remove LKG SDK download for source-build.

### DIFF
--- a/build/DotnetCoreSdkLKG.props
+++ b/build/DotnetCoreSdkLKG.props
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <_DownloadAndExtractItem Include="DotNetCoreSdkLKGArchive"
-                           Condition="!Exists('$(DotNetCoreSdkLKGArchive)')">
+                           Condition="!Exists('$(DotNetCoreSdkLKGArchive)') and '$(DotNetBuildFromSource)' != 'true'">
       <Url>$(DotNetCoreSdkLKGDownloadUrl)</Url>
       <DownloadFileName>$(DotNetCoreSdkLKGArchive)</DownloadFileName>
       <ExtractDestination>$(DotNetCoreSdkLKGPublishDirectory)</ExtractDestination>


### PR DESCRIPTION
This is not needed in source-build and fails in the offline configuration.