### PR TITLE
Insert updated NuGet

### DIFF
--- a/build/DependencyVersions.props
+++ b/build/DependencyVersions.props
@@ -47,7 +47,7 @@
     <MicrosoftDotNetProjectJsonMigrationPackageVersion>1.3.1</MicrosoftDotNetProjectJsonMigrationPackageVersion>
     <MicrosoftDotNetToolsMigrateCommandPackageVersion>$(MicrosoftDotNetProjectJsonMigrationPackageVersion)</MicrosoftDotNetToolsMigrateCommandPackageVersion>
     <MicrosoftDotNetArchivePackageVersion>0.2.0-beta-63027-01</MicrosoftDotNetArchivePackageVersion>
-    <NuGetBuildTasksPackageVersion>4.8.0-rtm.5362</NuGetBuildTasksPackageVersion>
+    <NuGetBuildTasksPackageVersion>4.9.0-preview3.5473</NuGetBuildTasksPackageVersion>
     <NuGetBuildTasksPackPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetBuildTasksPackPackageVersion>
     <NuGetCommonPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetCommonPackageVersion>
     <NuGetCommandLineXPlatPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetCommandLineXPlatPackageVersion>


### PR DESCRIPTION
The `dotnet list package` command depends on NuGet for its implementation.  So here I'm updating to a version of NuGet which should have that implementation, in order to be able to merge changes including the `list package` command into dotnet/cli in https://github.com/dotnet/cli/pull/9982