### PR TITLE
Set ExcludeAssets=All for Microsoft.TestPlatform.Cli

### DIFF
--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -19,15 +19,11 @@
   <ItemGroup>
     <PackageReference Include="NuGet.Build.Tasks" Version="$(NuGetBuildTasksPackageVersion)" />
     <PackageReference Include="Microsoft.Build.NuGetSdkResolver" Version="$(MicrosoftBuildNuGetSdkResolverPackageVersion)" />
-    <PackageReference Include="Microsoft.TestPlatform.CLI" Version="$(MicrosoftTestPlatformCLIPackageVersion)">
-      <ExcludeAssets>All</ExcludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.TestPlatform.CLI" Version="$(MicrosoftTestPlatformCLIPackageVersion)" ExcludeAssets="All" />
     <PackageReference Include="Microsoft.TestPlatform.Build" Version="$(MicrosoftTestPlatformBuildPackageVersion)" />
     <PackageReference Condition=" '$(DotNetBuildFromSource)' != 'true' " Include="NuGet.Localization" Version="$(NuGetProjectModelPackageVersion)" />
     <PackageReference Include="NuGet.ProjectModel" Version="$(NuGetProjectModelPackageVersion)" />
-    <PackageReference Include="Microsoft.NETCore.Compilers" Version="$(MicrosoftNETCoreCompilersPackageVersion)">
-      <ExcludeAssets>All</ExcludeAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.NETCore.Compilers" Version="$(MicrosoftNETCoreCompilersPackageVersion)" ExcludeAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -19,7 +19,9 @@
   <ItemGroup>
     <PackageReference Include="NuGet.Build.Tasks" Version="$(NuGetBuildTasksPackageVersion)" />
     <PackageReference Include="Microsoft.Build.NuGetSdkResolver" Version="$(MicrosoftBuildNuGetSdkResolverPackageVersion)" />
-    <PackageReference Include="Microsoft.TestPlatform.CLI" Version="$(MicrosoftTestPlatformCLIPackageVersion)" />
+    <PackageReference Include="Microsoft.TestPlatform.CLI" Version="$(MicrosoftTestPlatformCLIPackageVersion)">
+      <ExcludeAssets>All</ExcludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.TestPlatform.Build" Version="$(MicrosoftTestPlatformBuildPackageVersion)" />
     <PackageReference Condition=" '$(DotNetBuildFromSource)' != 'true' " Include="NuGet.Localization" Version="$(NuGetProjectModelPackageVersion)" />
     <PackageReference Include="NuGet.ProjectModel" Version="$(NuGetProjectModelPackageVersion)" />

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -28,8 +28,12 @@
       <TestCliNuGetDirectory>$(NuGetPackagesDir)/microsoft.testplatform.cli/$(MicrosoftTestPlatformCLIPackageVersion)/contentFiles/any/netcoreapp2.0/</TestCliNuGetDirectory>
     </PropertyGroup>
     <ItemGroup>
+      <TestCliBitsToExclude Include="$(TestCliNuGetDirectory)NewtonSoft.Json.dll" />
+      <TestCliBitsToExclude Include="$(TestCliNuGetDirectory)Microsoft.DotNet.PlatformAbstractions.dll" />
+      <TestCliBitsToExclude Include="$(TestCliNuGetDirectory)Microsoft.Extensions.DependencyModel.dll" />
+      <TestCliBitsToExclude Include="$(TestCliNuGetDirectory)System.Xml.XPath.XmlDocument.dll" />
       <TestCliBits Include="$(TestCliNuGetDirectory)**/*"
-                   Exclude="$(TestCliNuGetDirectory)NewtonSoft.Json.dll;$(TestCliNuGetDirectory)Microsoft.DotNet.PlatformAbstractions.dll;$(TestCliNuGetDirectory)Microsoft.Extensions.DependencyModel.dll;$(TestCliNuGetDirectory)System.Xml.XPath.XmlDocument.dll" />
+                   Exclude="@(TestCliBitsToExclude)" />
     </ItemGroup>
     <Copy SourceFiles="@(TestCliBits)" DestinationFiles="@(TestCliBits->'$(OutputPath)/%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>

--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -22,6 +22,18 @@
     <Delete Files="@(RoslynFrameworkAssemblies)" />
   </Target>
 
+  <Target Name="PublishTestCli"
+          BeforeTargets="Build">
+    <PropertyGroup>
+      <TestCliNuGetDirectory>$(NuGetPackagesDir)/microsoft.testplatform.cli/$(MicrosoftTestPlatformCLIPackageVersion)/contentFiles/any/netcoreapp2.0/</TestCliNuGetDirectory>
+    </PropertyGroup>
+    <ItemGroup>
+      <TestCliBits Include="$(TestCliNuGetDirectory)**/*"
+                   Exclude="$(TestCliNuGetDirectory)NewtonSoft.Json.dll;$(TestCliNuGetDirectory)Microsoft.DotNet.PlatformAbstractions.dll;$(TestCliNuGetDirectory)Microsoft.Extensions.DependencyModel.dll;$(TestCliNuGetDirectory)System.Xml.XPath.XmlDocument.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(TestCliBits)" DestinationFiles="@(TestCliBits->'$(OutputPath)/%(RecursiveDir)%(Filename)%(Extension)')" />
+  </Target>
+
   <Target Name="PublishFSharp"
           BeforeTargets="Build">
     <MSBuild


### PR DESCRIPTION
Microsoft.TestPlatform.Cli has all its files as ContentFiles, including some dependencies, like NewtonSoft.Json. Those dependencies have versions older that what we expect and are overwritting our own. This change set ExcludeAssets all on this package and manually copy bits to the toolset folder, excluding the dependencies we already have.
