### PR TITLE
Putting System.Xml.XPath.XmlDocument.dll back as a dependency of Microsoft.TestPlatform.Cli

### DIFF
--- a/src/redist/targets/GenerateLayout.targets
+++ b/src/redist/targets/GenerateLayout.targets
@@ -31,7 +31,6 @@
       <TestCliBitsToExclude Include="$(TestCliNuGetDirectory)NewtonSoft.Json.dll" />
       <TestCliBitsToExclude Include="$(TestCliNuGetDirectory)Microsoft.DotNet.PlatformAbstractions.dll" />
       <TestCliBitsToExclude Include="$(TestCliNuGetDirectory)Microsoft.Extensions.DependencyModel.dll" />
-      <TestCliBitsToExclude Include="$(TestCliNuGetDirectory)System.Xml.XPath.XmlDocument.dll" />
       <TestCliBits Include="$(TestCliNuGetDirectory)**/*"
                    Exclude="@(TestCliBitsToExclude)" />
     </ItemGroup>


### PR DESCRIPTION
Putting System.Xml.XPath.XmlDocument.dll back as a dependency of Microsoft.TestPlatform.Cli. I took it out thinking we had other parts depending on it.
