### PR TITLE
add windowsdesktop feed

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -4,6 +4,5 @@
   <packageSources>
     <clear/>
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
-    <add key="dotnet-windowsdesktop" value="https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json" />
   </packageSources>
 </configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -4,5 +4,6 @@
   <packageSources>
     <clear/>
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="dotnet-windowsdesktop" value="https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json" />
   </packageSources>
 </configuration>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -25,9 +25,9 @@
       <Uri>https://github.com/aspnet/AspNetCore-Tooling</Uri>
       <Sha></Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.WindowsDesktop" Version="3.0.0-alpha-27309-1">
+    <Dependency Name="Microsoft.NET.Sdk.WindowsDesktop" Version="3.0.0-preview-27310-7">
       <Uri>https://devdiv.visualstudio.com/DevDiv/_git/DotNet-Trusted</Uri>
-      <Sha>63610380c84a0d348c63651e9194aac5a87738b0</Sha>
+      <Sha>0f06f9b915f7fb35d7245d168b1428f377abc76c</Sha>
     </Dependency>
     <Dependency Name="NuGet.Build.Tasks" Version="5.0.0-preview1.5663">
       <Uri>https://github.com/nuget/nuget.client</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -67,7 +67,7 @@
       https://dotnet.myget.org/F/dotnet-cli/api/v3/index.json;
       https://dotnet.myget.org/F/dotnet-core/api/v3/index.json;
       https://dotnet.myget.org/F/vstest/api/v3/index.json;
-      https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180725-02/final/index.json
+      https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180725-02/final/index.json;
       https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json
     </RestoreSources>
   </PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -25,7 +25,7 @@
     <MicrosoftNETSdkWebPackageVersion>3.0.100-preview.18621.22</MicrosoftNETSdkWebPackageVersion>
     <MicrosoftNETSdkPublishPackageVersion>$(MicrosoftNETSdkWebPackageVersion)</MicrosoftNETSdkPublishPackageVersion>
     <MicrosoftNETSdkWebProjectSystemPackageVersion>$(MicrosoftNETSdkWebPackageVersion)</MicrosoftNETSdkWebProjectSystemPackageVersion>
-    <MicrosoftNETSdkWindowsDesktopPackageVersion>3.0.0-alpha-27309-3</MicrosoftNETSdkWindowsDesktopPackageVersion>
+    <MicrosoftNETSdkWindowsDesktopPackageVersion>3.0.0-preview-27310-7</MicrosoftNETSdkWindowsDesktopPackageVersion>
     <MicrosoftDotNetPlatformAbstractionsPackageVersion>2.2.0-preview1-26620-03</MicrosoftDotNetPlatformAbstractionsPackageVersion>
     <NuGetBuildTasksPackageVersion>5.0.0-preview1.5663</NuGetBuildTasksPackageVersion>
     <NuGetBuildTasksPackPackageVersion>$(NuGetBuildTasksPackageVersion)</NuGetBuildTasksPackPackageVersion>
@@ -68,6 +68,7 @@
       https://dotnet.myget.org/F/dotnet-core/api/v3/index.json;
       https://dotnet.myget.org/F/vstest/api/v3/index.json;
       https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180725-02/final/index.json
+      https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json
     </RestoreSources>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
- Add new windowsdesktop feed since this build also consumes the windowsdesktop outputs
- Mirrors the change done in coresdk at https://github.com/dotnet/core-sdk/pull/264/files