### PR TITLE
Import the Microsoft.Dotnet.Build.Bundle package

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -48,6 +48,11 @@
       <Sha>
       </Sha>
     </Dependency>
+    <Dependency Name="Microsoft.NET.Build.Bundle" Version="3.0.0-preview4-27527-19">
+      <Uri>https://github.com/dotnet/core-setup</Uri>
+      <Sha>
+      </Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19171.6">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -69,6 +69,10 @@
     <ILLinkTasksPackageVersion>0.1.6-prerelease.19164.1</ILLinkTasksPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
+    <!-- Dependencies from https://github.com/dotnet/core-setup -->
+    <MicrosoftNETBuildBundlePackageVersion>3.0.0-preview4-27527-19</MicrosoftNETBuildBundlePackageVersion>
+  </PropertyGroup>
+  <PropertyGroup>
     <MicrosoftDotNetPlatformAbstractionsPackageVersion>2.2.0-preview1-26620-03</MicrosoftDotNetPlatformAbstractionsPackageVersion>
     <MicrosoftDotNetCliUtilsPackageVersion>2.2.100-refac-20180613-1</MicrosoftDotNetCliUtilsPackageVersion>
     <SystemDataSqlClientVersionPackageVersion>4.3.0</SystemDataSqlClientVersionPackageVersion>

--- a/src/redist/targets/BundledSdks.targets
+++ b/src/redist/targets/BundledSdks.targets
@@ -11,5 +11,6 @@
     <BundledSdk Include="FSharp.NET.Sdk" Version="1.0.4-bundled-0100" />
     <BundledSdk Include="Microsoft.Docker.Sdk" Version="1.1.0" />
     <BundledSdk Include="ILLink.Tasks" Version="$(ILLinkTasksPackageVersion)" />
+    <BundledSdk Include="Microsoft.NET.Build.Bundle" Version="$(MicrosoftNETBuildBundlePackageVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This change adds the single-file bundler to the .Net core toolset.
The bundler is a tool that packs an app, its dependencies, the host and
optionally the runtime into a single executable file, for ease of distribution.

The Bundle tool will be invoked form the SDK, as part of dotnet CLI.
(dotnet publish /p:PublishSingleFile=true)

Further details about single-file publishing can be here:
https://github.com/dotnet/designs/blob/master/accepted/single-file/design.md