### PR TITLE
Removing NuGet and Test.SDK from Version.Details.xml

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -29,16 +29,6 @@
       <Uri>https://dev.azure.com/devdiv/DevDiv/_git/DotNet-Trusted</Uri>
       <Sha>5cd1bc54eca491024d501e926f7fb058dbf9e657</Sha>
     </Dependency>
-    <Dependency Name="NuGet.Build.Tasks" Version="5.0.0-preview1.5663">
-      <Uri>https://github.com/nuget/nuget.client</Uri>
-      <Sha>
-      </Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.NET.Test.Sdk" Version="15.9.0">
-      <Uri>https://github.com/microsoft/vstest</Uri>
-      <Sha>
-      </Sha>
-    </Dependency>
     <Dependency Name="Microsoft.NET.Sdk.Web" Version="3.0.100-preview4.19173.1">
       <Uri>https://github.com/aspnet/websdk</Uri>
       <Sha>6d73054ad65eb81702a58efa5e3c6991f7f57749</Sha>


### PR DESCRIPTION
Removed these dependencies so that they don't fail DARC publishing in the build, given that these two dependencies are not publishing to DARC yet.