### PR TITLE
Add nuget.client's feed URL

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -97,6 +97,7 @@
       https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json;
       https://dotnetfeed.blob.core.windows.net/dotnet-sdk/index.json;
       https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore-tooling/index.json;
+      https://dotnetfeed.blob.core.windows.net/nuget-nugetclient/index.json;
       https://dotnet.myget.org/F/dotnet-core/api/v3/index.json;
       https://dotnet.myget.org/F/templating/api/v3/index.json;
       https://dotnet.myget.org/F/dotnet-web/api/v3/index.json;
@@ -111,7 +112,6 @@
       https://dotnet.myget.org/F/vstest/api/v3/index.json;
       https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180725-02/final/index.json;
       https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json
-      https://dotnetfeed.blob.core.windows.net/nuget-nugetclient/index.json;
     </RestoreSources>
   </PropertyGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -111,6 +111,7 @@
       https://dotnet.myget.org/F/vstest/api/v3/index.json;
       https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180725-02/final/index.json;
       https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json
+      https://dotnetfeed.blob.core.windows.net/nuget-nugetclient/index.json;
     </RestoreSources>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
[NOMERGE!] Added feed is not created yet. 

Nuget client will start pushing their packages to "https://dotnetfeed.blob.core.windows.net/nuget-nugetclient" so in order to get the latest we need to add it to RestoreSources.

@dtivel 

skipciplease