### PR TITLE
Remove Microsoft.NET.Build.Bundle package

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -46,10 +46,6 @@
       <Uri>https://github.com/mono/linker</Uri>
       <Sha>c09c490012b1e11cf6d52a6c6a486d4dc5f401bc</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Build.Bundle" Version="3.0.0-preview5-27611-16">
-      <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>64572b598acce31a45dbb44f7ed063a8ef4a3cd9</Sha>
-    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19218.4">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -69,10 +69,6 @@
     <ILLinkTasksPackageVersion>0.1.6-prerelease.19218.1</ILLinkTasksPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Dependencies from https://github.com/dotnet/core-setup -->
-    <MicrosoftNETBuildBundlePackageVersion>3.0.0-preview5-27611-16</MicrosoftNETBuildBundlePackageVersion>
-  </PropertyGroup>
-  <PropertyGroup>
     <MicrosoftDotNetPlatformAbstractionsPackageVersion>2.2.0-preview1-26620-03</MicrosoftDotNetPlatformAbstractionsPackageVersion>
     <MicrosoftDotNetCliUtilsPackageVersion>2.2.100-refac-20180613-1</MicrosoftDotNetCliUtilsPackageVersion>
     <SystemDataSqlClientVersionPackageVersion>4.3.0</SystemDataSqlClientVersionPackageVersion>

--- a/src/redist/targets/BundledSdks.targets
+++ b/src/redist/targets/BundledSdks.targets
@@ -11,6 +11,5 @@
     <BundledSdk Include="FSharp.NET.Sdk" Version="1.0.4-bundled-0100" />
     <BundledSdk Include="Microsoft.Docker.Sdk" Version="1.1.0" />
     <BundledSdk Include="ILLink.Tasks" Version="$(ILLinkTasksPackageVersion)" />
-    <BundledSdk Include="Microsoft.NET.Build.Bundle" Version="$(MicrosoftNETBuildBundlePackageVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The application bundler was originally intended to be used
as a command line tool via the Microsoft.NET.Build.Bundle package.

However, this plan was subsequently changed.
The bundler is now a library in the Microsoft.NET.HostModel package,
and is directly imported in the SDK repo.

Therefore, remove the Microsoft.NET.Build.Bundle package from the toolset.