### PR TITLE
Writing the version of the toolset build to a file and reading it dur…

### DIFF
--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -12,18 +12,23 @@
   <ItemGroup>
     <ToolsetAssetsToPublish Include="$(ArtifactsNonShippingPackagesDir)*.zip" />
   </ItemGroup>
-  
+
+  <Target Name="ReadToolsetVersion">
+    <ReadLinesFromFile File="$(ArtifactsBinDir)version.txt">
+      <Output TaskParameter="Lines" ItemName="ToolsetVersion"/>
+    </ReadLinesFromFile>
+
+    <CreateProperty Value="@(ToolsetVersion)">
+      <Output TaskParameter="Value" PropertyName="ToolsetVersionValue" />
+    </CreateProperty>
+  </Target>
+
   <!-- We use a separate target to publish this to blob storage so that we can push this to
        a relative path inside the blob storage. -->
-  <Target Name="PublishToolsetAssets" BeforeTargets="Publish" Condition="$(PublishToAzure)">
-    <PropertyGroup>
-      <Version Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</Version>
-      <Version Condition=" '$(Version)' == '' ">$(VersionPrefix)</Version>
-    </PropertyGroup>
-
+  <Target Name="PublishToolsetAssets" DependsOnTargets="ReadToolsetVersion" BeforeTargets="Publish" Condition="$(PublishToAzure)">
     <ItemGroup>
       <ToolsetAssetsToPushToBlobFeed Include="@(ToolsetAssetsToPublish)" IsShipping="false" >
-        <RelativeBlobPath>$(BlobStoragePartialRelativePath)/$(Version)/$([System.String]::Copy('%(Filename)%(Extension)').Replace('\' ,'/'))</RelativeBlobPath>
+        <RelativeBlobPath>$(BlobStoragePartialRelativePath)/$(ToolsetVersionValue)/$([System.String]::Copy('%(Filename)%(Extension)').Replace('\' ,'/'))</RelativeBlobPath>
         <ManifestArtifactData>ShipInstaller=dotnetcli</ManifestArtifactData>
       </ToolsetAssetsToPushToBlobFeed>
     </ItemGroup>

--- a/src/redist/targets/GenerateArchive.targets
+++ b/src/redist/targets/GenerateArchive.targets
@@ -14,6 +14,8 @@
       <ArtifactNameWithVersionSdk>$(ArtifactNameSdk)-$(Version)</ArtifactNameWithVersionSdk>
 
       <ArtifactNameWithVersionSdkLanguagePack>$(ArtifactNameSdkLanguagePack)-$(Version)</ArtifactNameWithVersionSdkLanguagePack>
+
+      <VersionFilePath>$(ArtifactsBinDir)version.txt</VersionFilePath>
     </PropertyGroup>
 
     <ZipFileCreateFromDirectory
@@ -25,5 +27,10 @@
         SourceDirectory="$(SdkLanguagePackOutputDirectory)"
         DestinationArchive="$(ArtifactsNonShippingPackagesDir)$(ArtifactNameWithVersionSdkLanguagePack).zip"
         OverwriteDestination="true" />
+
+    <WriteLinesToFile
+        File="$(VersionFilePath)"
+        Lines="$(Version)"
+        Overwrite="true" />
   </Target>
 </Project>


### PR DESCRIPTION
Writing the version of the toolset build to a file and reading it during publish. We have to do this because Arcade does not make version information available during publish.

I tested this by publishing to a blob storage that I own. The folder version was honored properly.