### PR TITLE
Versions of WPF WindowsDesktop SDK should be routed through Versions from Core Setup

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -29,6 +29,7 @@
       <Uri>https://github.com/aspnet/AspNetCore-Tooling</Uri>
       <Sha>7fd95acc8d6a7b6f547f4e6fd41e6efbf526e428</Sha>
     </Dependency>
+    <!-- For coherency purposes, this version should be gated by the version of wpf routed via core setup -->
     <Dependency Name="Microsoft.NET.Sdk.WindowsDesktop" Version="3.0.0-preview6.19263.3" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/wpf</Uri>
       <Sha>90a570d65d2e032196b9bad9d8b2bff783d0ccc3</Sha>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview5-27611-16">
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview6-27715-03">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>1dfb3faf2fe573b9a0c3e5a0b7f83a2992093c6d</Sha>
+      <Sha>b0ecbd95b53d3bcda379199b87832ce707623ef2</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Cli.Runtime" Version="3.0.100-preview6.19264.2">
+    <Dependency Name="Microsoft.DotNet.Cli.Runtime" Version="3.0.100-preview6.19265.1">
       <Uri>https://github.com/dotnet/cli</Uri>
-      <Sha>1df8d22ca164e4f1ff5e715b57458c93ccfc8056</Sha>
+      <Sha>792b2f140616dc0f3e263a51421229321e02c2dd</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Sdk" Version="3.0.100-preview6.19264.1">
       <Uri>https://github.com/dotnet/sdk</Uri>
@@ -30,9 +30,9 @@
       <Sha>face057d5fe9e48d1b75696843cffb22591c2c87</Sha>
     </Dependency>
     <!-- For coherency purposes, this version should be gated by the version of wpf routed via core setup -->
-    <Dependency Name="Microsoft.NET.Sdk.WindowsDesktop" Version="3.0.0-preview6.19264.3" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="Microsoft.NET.Sdk.WindowsDesktop" Version="3.0.0-preview6.19258.4" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/wpf</Uri>
-      <Sha>8cd5ce04b1918b063978b1a6661536bcba8bfb44</Sha>
+      <Sha>7551f19f92c1fd734ea77a689786c53e57ac47b5</Sha>
     </Dependency>
     <Dependency Name="NuGet.Build.Tasks" Version="5.1.0-rtm.5921">
       <Uri>https://github.com/nuget/nuget.client</Uri>
@@ -47,9 +47,9 @@
       <Uri>https://github.com/aspnet/websdk</Uri>
       <Sha>b02642c023e7e709c48e6c84f5289c372e66a986</Sha>
     </Dependency>
-    <Dependency Name="ILLink.Tasks" Version="0.1.6-prerelease.19263.1">
+    <Dependency Name="ILLink.Tasks" Version="0.1.6-prerelease.19265.1">
       <Uri>https://github.com/mono/linker</Uri>
-      <Sha>1b5cf6bcecd9c2f64c00d81fefe625e2a1f3537b</Sha>
+      <Sha>56ec7569e25dfa81b16c7b8c2fca6fe43c4a26b8</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Build.Bundle" Version="3.0.0-preview5-27611-16">
       <Uri>https://github.com/dotnet/core-setup</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
+    <Dependency Name="Microsoft.NETCore.App" Version="3.0.0-preview5-27611-16">
+      <Uri>https://github.com/dotnet/core-setup</Uri>
+      <Sha>1dfb3faf2fe573b9a0c3e5a0b7f83a2992093c6d</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.DotNet.Cli.Runtime" Version="3.0.100-preview6.19263.3">
       <Uri>https://github.com/dotnet/cli</Uri>
       <Sha>7d55db72fa1628bf593b7bfe1cabeb32b5540fca</Sha>
@@ -25,7 +29,7 @@
       <Uri>https://github.com/aspnet/AspNetCore-Tooling</Uri>
       <Sha>7fd95acc8d6a7b6f547f4e6fd41e6efbf526e428</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.WindowsDesktop" Version="3.0.0-preview6.19263.3">
+    <Dependency Name="Microsoft.NET.Sdk.WindowsDesktop" Version="3.0.0-preview6.19263.3" CoherentParentDependency="Microsoft.NETCore.App">
       <Uri>https://github.com/dotnet/wpf</Uri>
       <Sha>90a570d65d2e032196b9bad9d8b2bff783d0ccc3</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,7 +13,7 @@
   <!-- Production Dependencies -->
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/cli  -->
-    <MicrosoftDotNetCliRuntimePackageVersion>3.0.100-preview6.19264.2</MicrosoftDotNetCliRuntimePackageVersion>
+    <MicrosoftDotNetCliRuntimePackageVersion>3.0.100-preview6.19265.1</MicrosoftDotNetCliRuntimePackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/sdk -->
@@ -48,7 +48,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://devdiv.visualstudio.com/DevDiv/_git/DotNet-Trusted -->
-    <MicrosoftNETSdkWindowsDesktopPackageVersion>3.0.0-preview6.19264.3</MicrosoftNETSdkWindowsDesktopPackageVersion>
+    <MicrosoftNETSdkWindowsDesktopPackageVersion>3.0.0-preview6.19258.4</MicrosoftNETSdkWindowsDesktopPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/nuget/nuget.client -->
@@ -66,7 +66,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/mono/linker -->
-    <ILLinkTasksPackageVersion>0.1.6-prerelease.19263.1</ILLinkTasksPackageVersion>
+    <ILLinkTasksPackageVersion>0.1.6-prerelease.19265.1</ILLinkTasksPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/core-setup -->


### PR DESCRIPTION
WPF sends the WindowsDesktop SDK straight to the toolset while the binaries are sent to the SDK via core-setup. For coherency purposes, these should wait to update until wpf has been routed via core setup as well.

/cc @mmitche @vatsan-madhavan @AdamYoblick
