### PR TITLE
Remove Microsoft.NET.Build.Bundle package

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -51,10 +51,6 @@
       <Uri>https://github.com/mono/linker</Uri>
       <Sha>14b4a919139031d10a374093862075d98715431b</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Build.Bundle" Version="3.0.0-preview5-27611-16">
-      <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>64572b598acce31a45dbb44f7ed063a8ef4a3cd9</Sha>
-    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19270.2">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -69,10 +69,6 @@
     <ILLinkTasksPackageVersion>0.1.6-prerelease.19272.1</ILLinkTasksPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Dependencies from https://github.com/dotnet/core-setup -->
-    <MicrosoftNETBuildBundlePackageVersion>3.0.0-preview5-27611-16</MicrosoftNETBuildBundlePackageVersion>
-  </PropertyGroup>
-  <PropertyGroup>
     <MicrosoftDotNetPlatformAbstractionsPackageVersion>2.2.0-preview1-26620-03</MicrosoftDotNetPlatformAbstractionsPackageVersion>
     <MicrosoftDotNetCliUtilsPackageVersion>2.2.100-refac-20180613-1</MicrosoftDotNetCliUtilsPackageVersion>
     <SystemDataSqlClientVersionPackageVersion>4.3.0</SystemDataSqlClientVersionPackageVersion>

--- a/src/redist/targets/BundledSdks.targets
+++ b/src/redist/targets/BundledSdks.targets
@@ -11,6 +11,5 @@
     <BundledSdk Include="FSharp.NET.Sdk" Version="1.0.4-bundled-0100" />
     <BundledSdk Include="Microsoft.Docker.Sdk" Version="1.1.0" />
     <BundledSdk Include="ILLink.Tasks" Version="$(ILLinkTasksPackageVersion)" />
-    <BundledSdk Include="Microsoft.NET.Build.Bundle" Version="$(MicrosoftNETBuildBundlePackageVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Remove Microsoft.NET.Build.Bundle package from the toolset
since it is no longer used.

The change was [committed](https://github.com/dotnet/toolset/commit/a99cc738c5c0a4d584584ea627f314ca77623dad) to release/3.0.1xx branch, but it did not flow into master branch. So committing it here.
