### PR TITLE
Remove unnecessary package refs from F# publishing

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -71,8 +71,6 @@
   <PropertyGroup>
     <MicrosoftDotNetPlatformAbstractionsPackageVersion>2.2.0-preview1-26620-03</MicrosoftDotNetPlatformAbstractionsPackageVersion>
     <MicrosoftDotNetCliUtilsPackageVersion>2.2.100-refac-20180613-1</MicrosoftDotNetCliUtilsPackageVersion>
-    <SystemDataSqlClientVersionPackageVersion>4.3.0</SystemDataSqlClientVersionPackageVersion>
-    <SystemRuntimeInteropServicesPackageVersion>4.3.0</SystemRuntimeInteropServicesPackageVersion>
     <XliffTasksPackageVersion>0.2.0-beta-000042</XliffTasksPackageVersion>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/tool_fsharp/tool_fsc.csproj
+++ b/src/tool_fsharp/tool_fsc.csproj
@@ -6,7 +6,5 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.FSharp.Compiler" Version="$(MicrosoftFSharpCompilerPackageVersion)" />
-    <PackageReference Include="System.Runtime.InteropServices" Version="$(SystemRuntimeInteropServicesPackageVersion)" />
-    <PackageReference Include="System.Data.SqlClient" Version="$(SystemDataSqlClientVersionPackageVersion)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
System.Data.SqlClient is getting flagged as a pre-built and it looks like F# doesn't require it anymore: https://github.com/dotnet/fsharp/pull/6274

I don't know why System.Runtime.InteropServices would be referenced either as it would be in the base shared framework. Possibly only because of transitive dependency from System.Data.SqlClient?

Fix https://github.com/dotnet/cli/issues/11460