### PR TITLE
Lift up dependencies to prevent build tasks from getting pinned versions

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -51,6 +51,18 @@
       <Uri>https://github.com/mono/linker</Uri>
       <Sha>2d3153b356d840819e19a5b2c4c16ada20ecaa53</Sha>
     </Dependency>
+    <Dependency Name="System.CodeDom" Version="4.6.0-preview7.19281.6">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha></Sha>
+    </Dependency>
+    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="4.6.0-preview7.19281.6">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha></Sha>
+    </Dependency>
+    <Dependency Name="System.Text.Encoding.CodePages" Version="4.6.0-preview7.19281.6">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha></Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19302.2">

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -69,6 +69,12 @@
     <ILLinkTasksPackageVersion>0.1.6-prerelease.19303.1</ILLinkTasksPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
+    <!-- Dependencies from https://github.com/dotnet/corefx -->
+    <SystemCodeDomPackageVersion>4.6.0-preview7.19281.6</SystemCodeDomPackageVersion>
+    <SystemTextEncodingCodePagesPackageVersion>4.6.0-preview7.19281.6</SystemTextEncodingCodePagesPackageVersion>
+    <SystemSecurityCryptographyProtectedDataPackageVersion>4.6.0-preview7.19281.6</SystemSecurityCryptographyProtectedDataPackageVersion>
+  </PropertyGroup>
+  <PropertyGroup>
     <MicrosoftDotNetPlatformAbstractionsPackageVersion>2.2.0-preview1-26620-03</MicrosoftDotNetPlatformAbstractionsPackageVersion>
     <MicrosoftDotNetCliUtilsPackageVersion>2.2.100-refac-20180613-1</MicrosoftDotNetCliUtilsPackageVersion>
     <SystemDataSqlClientVersionPackageVersion>4.3.0</SystemDataSqlClientVersionPackageVersion>

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -5,6 +5,7 @@
     <CopyBuildOutputToPublishDirectory>false</CopyBuildOutputToPublishDirectory>
     <AssetTargetFallback>dotnet5.4</AssetTargetFallback>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <DisableImplicitNETCorePlatformsReference>true</DisableImplicitNETCorePlatformsReference>
   </PropertyGroup>
 
   <Import Project="targets\BuildToolsetTasks.targets" />
@@ -24,6 +25,11 @@
     <PackageReference Condition=" '$(DotNetBuildFromSource)' != 'true' " Include="NuGet.Localization" Version="$(NuGetProjectModelPackageVersion)" />
     <PackageReference Include="NuGet.ProjectModel" Version="$(NuGetProjectModelPackageVersion)" />
     <PackageReference Include="Microsoft.NETCore.Compilers" Version="$(MicrosoftNETCoreCompilersPackageVersion)" ExcludeAssets="All" />
+
+    <!-- Lift up dependencies of dependencies to prevent build tasks from getting pinned to older versions -->
+    <PackageReference Include="System.CodeDom" Version="$(SystemCodeDomPackageVersion)" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="$(SystemTextEncodingCodePagesPackageVersion)" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="$(SystemSecurityCryptographyProtectedDataPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
When combined with dotnet/cli#11481, which removes migrate, which was pulling in the stale rosly, fix dotnet/cli#11444