### PR TITLE
Consolidate MSBuild* versions for source-build

### DIFF
--- a/src/toolset-tasks/toolset-tasks.csproj
+++ b/src/toolset-tasks/toolset-tasks.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="15.7.177" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.7.177" />
+    <PackageReference Include="Microsoft.Build" Version="15.7.179" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.7.179" />
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="NuGet.Versioning" Version="4.3.0" />


### PR DESCRIPTION
Consolidate versions of MSBuild* versions to 15.7.179 to allow source-build reference packages to only build one version.
