### PR TITLE
Add feeds from Versions.props to NuGet.config

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -4,5 +4,22 @@
   <packageSources>
     <clear />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
+    <add key="vstest" value="https://dotnet.myget.org/F/vstest/api/v3/index.json" />
+    <add key="dotnet-sdk" value="https://dotnetfeed.blob.core.windows.net/dotnet-sdk/index.json" />
+    <add key="aspnet-aspnetcore" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json" />
+    <add key="aspnet-aspnetcore-tooling" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore-tooling/index.json" />
+    <add key="nuget-nugetclient" value="https://dotnetfeed.blob.core.windows.net/nuget-nugetclient/index.json" />
+    <add key="myget-dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    <add key="templating" value="https://dotnet.myget.org/F/templating/api/v3/index.json" />
+    <add key="dotnet-web" value="https://dotnet.myget.org/F/dotnet-web/api/v3/index.json" />
+    <add key="roslyn" value="https://dotnet.myget.org/f/roslyn/api/v3/index.json" />
+    <add key="nuget-build" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json" />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <add key="container-tools" value="https://www.myget.org/F/container-tools-for-visual-studio/api/v3/index.json" />
+    <add key="aspnet-inputs" value="https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180420-03/aspnet-inputs/index.json" />
+    <add key="msbuild" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />
+    <add key="dotnet-cli" value="https://dotnet.myget.org/F/dotnet-cli/api/v3/index.json" />
+    <add key="orchestrated-release-2-1-final" value="https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180725-02/final/index.json" />
+    <add key="dotnet-windowsdesktop" value="https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
We need all restore sources to be located in NuGet.config since internal feeds can only be restored from there. More details including next steps [here](https://github.com/dotnet/arcade/blob/master/Documentation/RestoreSourcesUpdateStatus.md)