### PR TITLE
Revert no-op roslyn update

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -21,7 +21,7 @@
       <Uri>https://github.com/dotnet/fsharp</Uri>
       <Sha>d4884581c1e7a93232914a2e335928210d8ddd84</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.Compilers" Version="3.3.0-beta2-19381-19">
+    <Dependency Name="Microsoft.NETCore.Compilers" Version="3.3.0-beta2-19381-14">
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>ef3a7a3863ae53b610a4b0c3682a35cad0829583</Sha>
     </Dependency>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -33,7 +33,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/roslyn -->
-    <MicrosoftNETCoreCompilersPackageVersion>3.3.0-beta2-19381-19</MicrosoftNETCoreCompilersPackageVersion>
+    <MicrosoftNETCoreCompilersPackageVersion>3.3.0-beta2-19381-14</MicrosoftNETCoreCompilersPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore-Tooling -->


### PR DESCRIPTION
https://github.com/dotnet/toolset/pull/1943 was a no-op update with a rebuild of an old Roslyn commit, this reverts toolset to the state before that change. CC @mmitche 