### PR TITLE
Add ArtifactCategory to the list of properties, 3.0.1

### DIFF
--- a/eng/build.yml
+++ b/eng/build.yml
@@ -54,6 +54,7 @@ jobs:
                   /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)
                   /p:DotNetSymbolServerTokenSymWeb=$(symweb-symbol-server-pat)
                   /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
+                  /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
                   /p:PB_PublishType=$(_PublishType)
 
     steps:


### PR DESCRIPTION
Relates to: dotnet/arcade#3846

The ArtifactCategory is required, otherwise the RM release pipeline will keep complaining that this info is missing and opening issues in Arcade.