### PR TITLE
A couple exclusions for source-build

### DIFF
--- a/cli/test/Directory.Build.props
+++ b/cli/test/Directory.Build.props
@@ -3,5 +3,6 @@
 
   <PropertyGroup>
     <DisableImplicitFrameworkReferences>false</DisableImplicitFrameworkReferences>
+    <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
   </PropertyGroup>
 </Project>

--- a/src/redist/targets/BundledSdks.targets
+++ b/src/redist/targets/BundledSdks.targets
@@ -7,7 +7,7 @@
     <BundledSdk Include="Microsoft.NET.Sdk.Publish" Version="$(MicrosoftNETSdkPublishPackageVersion)" />
     <BundledSdk Include="Microsoft.NET.Sdk.Web.ProjectSystem" Version="$(MicrosoftNETSdkWebProjectSystemPackageVersion)" />
     <BundledSdk Include="Microsoft.NET.Sdk.Worker" Version="$(MicrosoftNETSdkWorkerPackageVersion)" />
-    <BundledSdk Include="Microsoft.NET.Sdk.WindowsDesktop" Version="$(MicrosoftNETSdkWindowsDesktopPackageVersion)" />
+    <BundledSdk Include="Microsoft.NET.Sdk.WindowsDesktop" Version="$(MicrosoftNETSdkWindowsDesktopPackageVersion)" Condition="'$(DotNetBuildFromSource)' != 'true'" />
     <BundledSdk Include="FSharp.NET.Sdk" Version="1.0.4-bundled-0100" />
     <BundledSdk Include="Microsoft.Docker.Sdk" Version="1.1.0" />
     <BundledSdk Include="ILLink.Tasks" Version="$(ILLinkTasksPackageVersion)" />


### PR DESCRIPTION
- Do not try to include the WindowsDesktop SDK (we don't have it).
- Exclude all test projects from source-build.