### PR TITLE
Fixup CPD on Microsoft.NET.Sdk.WindowsDesktop

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -41,10 +41,14 @@
       <Uri>https://github.com/aspnet/AspNetCore-Tooling</Uri>
       <Sha>9a8b07ac0b544bbc3cb69cf157383ce6b60eb570</Sha>
     </Dependency>
-    <!-- For coherency purposes, this version should be gated by the version of wpf routed via core setup -->
-    <Dependency Name="Microsoft.NET.Sdk.WindowsDesktop" Version="5.0.0-alpha1.19504.4" CoherentParentDependency="Microsoft.NETCore.App">
+        <Dependency Name="Microsoft.WindowsDesktop.App" Version="5.0.0-alpha1.19516.6">
+      <Uri>https://github.com/dotnet/windowsdesktop</Uri>
+      <Sha>90199f6947ffff8ba397cb3d921d7fbce3958d3a</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NET.Sdk.WindowsDesktop" Version="5.0.0-alpha1.19462.16" CoherentParentDependency="Microsoft.WindowsDesktop.App">
       <Uri>https://github.com/dotnet/wpf</Uri>
       <Sha>2e840efbac4cf916fe35d22d279d42ed02915cc6</Sha>
+      <Sha>11a8ba5060577dbddae4303e53583f8d4a82f172</Sha>
     </Dependency>
     <Dependency Name="NuGet.Build.Tasks" Version="5.3.0-rtm.6192">
       <Uri>https://github.com/NuGet/NuGet.Client</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -52,8 +52,8 @@
     <MicrosoftNETSdkWorkerPackageVersion>$(MicrosoftNETSdkWebPackageVersion)</MicrosoftNETSdkWorkerPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <!-- Dependencies from https://devdiv.visualstudio.com/DevDiv/_git/DotNet-Trusted -->
-    <MicrosoftNETSdkWindowsDesktopPackageVersion>5.0.0-alpha1.19504.4</MicrosoftNETSdkWindowsDesktopPackageVersion>
+    <!-- Dependencies from https://github.com/dotnet/wpf -->
+    <MicrosoftNETSdkWindowsDesktopPackageVersion>5.0.0-alpha1.19462.16</MicrosoftNETSdkWindowsDesktopPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/templating -->


### PR DESCRIPTION
Microsoft.NET.Sdk.WindowsDesktop has moved out of core-setup, so the CPD should be removed
