### PR TITLE
Fix failure with versions for official builds

### DIFF
--- a/TestAssets/TestPackages/dotnet-dependency-context-test/dotnet-dependency-context-test.csproj
+++ b/TestAssets/TestPackages/dotnet-dependency-context-test/dotnet-dependency-context-test.csproj
@@ -2,7 +2,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
 
   <PropertyGroup>
-    <VersionPrefix>1.0.0-rc</VersionPrefix>
     <!-- netcoreapp2.2 is the maximum TFM project tools support -->
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <OutputType>Exe</OutputType>

--- a/TestAssets/TestPackages/dotnet-desktop-binding-redirects/dotnet-desktop-binding-redirects.csproj
+++ b/TestAssets/TestPackages/dotnet-desktop-binding-redirects/dotnet-desktop-binding-redirects.csproj
@@ -2,7 +2,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), testAsset.props))\testAsset.props" />
 
   <PropertyGroup>
-    <VersionPrefix>1.0.0-rc</VersionPrefix>
     <TargetFramework>net451</TargetFramework>
     <AssemblyName>dotnet-desktop-binding-redirects</AssemblyName>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
Official builds were failing with:

> D:\a\1\s\.nuget\packages\microsoft.dotnet.arcade.sdk\5.0.0-beta.19515.2\tools\Version.targets(17,5): VersionPrefix is not a valid 3-part version: 1.0.0-rc [D:\a\1\s\TestAssets\TestPackages\dotnet-desktop-binding-redirects\dotnet-desktop-binding-redirects.csproj]

This should fix it