### PR TITLE
Reenable test - reference

### DIFF
--- a/test/Microsoft.DotNet.ShellShim.Tests/ShellShimRepositoryTests.cs
+++ b/test/Microsoft.DotNet.ShellShim.Tests/ShellShimRepositoryTests.cs
@@ -176,8 +176,7 @@ namespace Microsoft.DotNet.ShellShim.Tests
         }
 
         [Theory]
-        // https://github.com/dotnet/sdk/issues/3684
-        //[InlineData(false)]
+        [InlineData(false)]
         [InlineData(true)]
         public void GivenAnExceptionItWillRollback(bool testMockBehaviorIsInSync)
         {
@@ -240,8 +239,7 @@ namespace Microsoft.DotNet.ShellShim.Tests
         }
 
         [Theory]
-        // https://github.com/dotnet/sdk/issues/3684
-        //[InlineData(false)]
+        [InlineData(false)]
         [InlineData(true)]
         public void GivenAnInstalledShimRemoveDeletesTheShimFiles(bool testMockBehaviorIsInSync)
         {
@@ -308,8 +306,7 @@ namespace Microsoft.DotNet.ShellShim.Tests
         }
 
         [Theory]
-        //  https://github.com/dotnet/sdk/issues/3684
-        //[InlineData(false)]
+        [InlineData(false)]
         [InlineData(true)]
         public void GivenAnInstalledShimRemoveCommitsIfTransactionIsCompleted(bool testMockBehaviorIsInSync)
         {

--- a/test/Microsoft.DotNet.ToolPackage.Tests/ToolPackageUninstallerTests.cs
+++ b/test/Microsoft.DotNet.ToolPackage.Tests/ToolPackageUninstallerTests.cs
@@ -24,8 +24,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
     public class ToolPackageUninstallerTests : TestBase
     {
         [Theory]
-        //  https://github.com/dotnet/sdk/issues/3684
-        //[InlineData(false)]
+        [InlineData(false)]
         [InlineData(true)]
         public void GivenAnInstalledPackageUninstallRemovesThePackage(bool testMockBehaviorIsInSync)
         {
@@ -121,7 +120,7 @@ namespace Microsoft.DotNet.ToolPackage.Tests
                 storeQuery = toolPackageStore;
                 installer = new ToolPackageInstaller(
                     store: store,
-                    projectRestorer: new ProjectRestorer(reporter),
+                    projectRestorer: new Stage2ProjectRestorer(reporter),
                     tempProject: tempProject ?? GetUniqueTempProjectPathEachTest(),
                     offlineFeed: offlineFeed ?? new DirectoryPath("does not exist"));
                 uninstaller = new ToolPackageUninstaller(store);


### PR DESCRIPTION
only enable tests with log

for some reason https://github.com/dotnet/toolset/pull/3223 no longer repros after adding log