### PR TITLE
Target 5.0, update dependencies, fix telemetry test flakiness

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,7 +21,7 @@
     <DebugSymbols>true</DebugSymbols>
 
     <IsShippingPackage>false</IsShippingPackage>
-    <ToolsetTargetFramework>netcoreapp3.0</ToolsetTargetFramework>
+    <ToolsetTargetFramework>netcoreapp5.0</ToolsetTargetFramework>
     <LangVersion>latest</LangVersion>
 
     <ArtifactsShippingSymbolsDir>$(ArtifactsDir)symbols\$(Configuration)\Shipping</ArtifactsShippingSymbolsDir>

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,31 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <!-- Only specify feed for RepoToolset SDK (see https://github.com/Microsoft/msbuild/issues/2982) -->
   <packageSources>
     <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
     <add key="dotnet-core" value="https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json" />
     <add key="vstest" value="https://dotnet.myget.org/F/vstest/api/v3/index.json" />
-    <add key="dotnet-sdk" value="https://dotnetfeed.blob.core.windows.net/dotnet-sdk/index.json" />
-    <add key="aspnet-aspnetcore" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json" />
-    <add key="aspnet-aspnetcore-tooling" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore-tooling/index.json" />
     <add key="nuget-nugetclient" value="https://dotnetfeed.blob.core.windows.net/nuget-nugetclient/index.json" />
-    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
-    <add key="dotnet3" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3/nuget/v3/index.json" />
-    <add key="dotnet3-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3-transport/nuget/v3/index.json" />
-    <add key="dotnet3.1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1/nuget/v3/index.json" />
-    <add key="dotnet3.1-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1-transport/nuget/v3/index.json" />
-    <add key="myget-dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
-    <add key="templating" value="https://dotnet.myget.org/F/templating/api/v3/index.json" />
-    <add key="dotnet-web" value="https://dotnet.myget.org/F/dotnet-web/api/v3/index.json" />
-    <add key="roslyn" value="https://dotnet.myget.org/f/roslyn/api/v3/index.json" />
-    <add key="nuget-build" value="https://dotnet.myget.org/F/nuget-build/api/v3/index.json" />
-    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
     <add key="container-tools" value="https://www.myget.org/F/container-tools-for-visual-studio/api/v3/index.json" />
-    <add key="aspnet-inputs" value="https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180420-03/aspnet-inputs/index.json" />
-    <add key="msbuild" value="https://dotnet.myget.org/F/msbuild/api/v3/index.json" />
-    <add key="dotnet-cli" value="https://dotnet.myget.org/F/dotnet-cli/api/v3/index.json" />
-    <add key="orchestrated-release-2-1-final" value="https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180725-02/final/index.json" />
-    <add key="dotnet-windowsdesktop" value="https://dotnetfeed.blob.core.windows.net/dotnet-windowsdesktop/index.json" />
-    <add key="aspnet-aspnetcore" value="https://dotnetfeed.blob.core.windows.net/aspnet-aspnetcore/index.json" />
+    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+    <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
+    <add key="dotnet5-transport" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5-transport/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/TestAssets/TestProjects/NuGetConfigDependentProject/NuGetConfigDependentProject.csproj
+++ b/TestAssets/TestProjects/NuGetConfigDependentProject/NuGetConfigDependentProject.csproj
@@ -7,6 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NuGet.Configuration" Version="4.3.0-preview3-4146" />
+    <PackageReference Include="NuGet.Configuration" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/TestAssets/TestProjects/NuGetConfigProfile/NuGetConfigFilterProfile.xml
+++ b/TestAssets/TestProjects/NuGetConfigProfile/NuGetConfigFilterProfile.xml
@@ -1,3 +1,3 @@
 <StoreArtifacts>
-    <Package Id="NuGet.Configuration" Version ="4.3.0-preview3-4146"/>
+    <Package Id="NuGet.Configuration" Version="4.3.0"/>
 </StoreArtifacts>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,21 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.TemplateEngine.Cli" Version="5.0.0-alpha1.19428.1">
-      <Uri>https://github.com/dotnet/templating</Uri>
-      <Sha>40bcaca36d5db25dae9f9ad7e85891fc73714320</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.NETCore.App" Version="5.0.0-alpha1.19518.1">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="5.0.0-alpha1.19522.6">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>83b657163a4a0fa7f64ed635ef65d830d48753e2</Sha>
+      <Sha>57ce3c5fafe565a9b1f397cada1c82b66450dd47</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="5.0.0-alpha1.19515.17">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-alpha1.19522.6">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>0ceceab994c8e965bf50b11fc230dc2ea67aa1ec</Sha>
+      <Sha>57ce3c5fafe565a9b1f397cada1c82b66450dd47</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Cli.Runtime" Version="5.0.100-alpha1.19516.1">
-      <Uri>https://github.com/dotnet/cli</Uri>
-      <Sha>fb9280b4458ebf8a5d3679e85f0878d07d6d0635</Sha>
+    <Dependency Name="Microsoft.DotNet.PlatformAbstractions" Version="5.0.0-alpha1.19522.6">
+      <Uri>https://github.com/dotnet/core-setup</Uri>
+      <Sha>57ce3c5fafe565a9b1f397cada1c82b66450dd47</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NET.HostModel" Version="5.0.0-alpha1.19522.6">
+      <Uri>https://github.com/dotnet/core-setup</Uri>
+      <Sha>57ce3c5fafe565a9b1f397cada1c82b66450dd47</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="5.0.0-alpha1.19522.6">
+      <Uri>https://github.com/dotnet/core-setup</Uri>
+      <Sha>57ce3c5fafe565a9b1f397cada1c82b66450dd47</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="5.0.0-alpha1.19522.6">
+      <Uri>https://github.com/dotnet/core-setup</Uri>
+      <Sha>57ce3c5fafe565a9b1f397cada1c82b66450dd47</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Sdk" Version="5.0.100-alpha1.19501.2">
       <Uri>https://github.com/dotnet/sdk</Uri>
@@ -25,9 +33,9 @@
       <Uri>https://github.com/dotnet/CliCommandLineParser</Uri>
       <Sha>0e89c2116ad28e404ba56c14d1c3f938caa25a01</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Build" Version="16.3.0-preview-19456-02">
+    <Dependency Name="Microsoft.Build" Version="16.4.0-preview-19460-01">
       <Uri>https://github.com/Microsoft/msbuild</Uri>
-      <Sha>ee8294b5597fe21ca5c44c8fd4c142d27fcec2cb</Sha>
+      <Sha>e460c009a8fc6db1e3a40ec17d380dfd09344e1e</Sha>
     </Dependency>
     <Dependency Name="Microsoft.FSharp.Compiler" Version="10.7.0-beta.19460.5">
       <Uri>https://github.com/dotnet/fsharp</Uri>
@@ -37,21 +45,20 @@
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>3c865821f2864393a0ff7fe22c92ded6d51a546c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="5.0.0-alpha1.19427.5">
+    <Dependency Name="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="5.0.0-alpha1.19522.2">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>
-      <Sha>af0a2048a207b49bee29de9629208afd8ba27da4</Sha>
+      <Sha>1189a2c294df55d7a67f1bc6ea74d74858f467bd</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.Razor" Version="5.0.0-alpha1.19515.1">
+    <Dependency Name="Microsoft.NET.Sdk.Razor" Version="5.0.0-alpha1.19519.1">
       <Uri>https://github.com/aspnet/AspNetCore-Tooling</Uri>
-      <Sha>9a8b07ac0b544bbc3cb69cf157383ce6b60eb570</Sha>
+      <Sha>9dd83077aa7dda45acea084a0dde6265393a12d6</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="5.0.0-alpha1.19516.6">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="5.0.0-alpha1.19522.3">
       <Uri>https://github.com/dotnet/windowsdesktop</Uri>
-      <Sha>90199f6947ffff8ba397cb3d921d7fbce3958d3a</Sha>
+      <Sha>f3b299f3cd91a42c0c0285cf0709f23a74d13357</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Sdk.WindowsDesktop" Version="5.0.0-alpha1.19462.16" CoherentParentDependency="Microsoft.WindowsDesktop.App">
       <Uri>https://github.com/dotnet/wpf</Uri>
-      <Sha>11a8ba5060577dbddae4303e53583f8d4a82f172</Sha>
       <Sha>11a8ba5060577dbddae4303e53583f8d4a82f172</Sha>
     </Dependency>
     <Dependency Name="NuGet.Build.Tasks" Version="5.3.0-rtm.6192">
@@ -62,31 +69,31 @@
       <Uri>https://github.com/microsoft/vstest</Uri>
       <Sha>32a75bd117876d8ad9c023cd0029df97412d1706</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.Web" Version="5.0.100-alpha1.19467.1">
+    <Dependency Name="Microsoft.NET.Sdk.Web" Version="5.0.100-alpha1.19522.2">
       <Uri>https://github.com/aspnet/websdk</Uri>
-      <Sha>aa5e59dee79125aabb896c608bcdd605fbd0409c</Sha>
+      <Sha>67228e1a9a8b400bccf8429c7840765ed2e49a48</Sha>
     </Dependency>
     <Dependency Name="ILLink.Tasks" Version="0.1.6-prerelease.19380.1">
       <Uri>https://github.com/mono/linker</Uri>
       <Sha>18ff3f49475c3fc3fafa1d17161b1525eea182d8</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="5.0.0-alpha1.19517.14" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="System.CodeDom" Version="5.0.0-alpha1.19521.4" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>296bbb0d56d9c236a44700d78a0251ed3faa22e1</Sha>
+      <Sha>46299619e290936c495264162ede68354ced5b18</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="5.0.0-alpha1.19517.14" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="5.0.0-alpha1.19521.4" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>296bbb0d56d9c236a44700d78a0251ed3faa22e1</Sha>
+      <Sha>46299619e290936c495264162ede68354ced5b18</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Encoding.CodePages" Version="5.0.0-alpha1.19517.14" CoherentParentDependency="Microsoft.NETCore.App">
+    <Dependency Name="System.Text.Encoding.CodePages" Version="5.0.0-alpha1.19521.4" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>296bbb0d56d9c236a44700d78a0251ed3faa22e1</Sha>
+      <Sha>46299619e290936c495264162ede68354ced5b18</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.19518.2">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19463.3">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>f59f1ebe9b293ad523d3bfa4e5cffc663708ef11</Sha>
+      <Sha>7b731032220c21a3ed0021c72757b1f3122579b2</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -99,9 +99,9 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19463.3">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="5.0.0-beta.19518.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>7b731032220c21a3ed0021c72757b1f3122579b2</Sha>
+      <Sha>f59f1ebe9b293ad523d3bfa4e5cffc663708ef11</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -89,6 +89,10 @@
       <Uri>https://github.com/dotnet/corefx</Uri>
       <Sha>46299619e290936c495264162ede68354ced5b18</Sha>
     </Dependency>
+    <Dependency Name="System.Resources.Extensions" Version="5.0.0-alpha1.19521.4" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+      <Uri>https://github.com/dotnet/corefx</Uri>
+      <Sha>46299619e290936c495264162ede68354ced5b18</Sha>
+    </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
     <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="1.0.0-beta.19463.3">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,29 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="5.0.0-alpha1.19522.6">
-      <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>57ce3c5fafe565a9b1f397cada1c82b66450dd47</Sha>
+    <Dependency Name="Microsoft.TemplateEngine.Cli" Version="5.0.0-alpha1.19516.1">
+      <Uri>https://github.com/dotnet/templating</Uri>
+      <Sha>6f180514b4aefc006d50c07c947da61e0ac2ed4c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-alpha1.19522.6">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="5.0.0-alpha1.19523.2">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>57ce3c5fafe565a9b1f397cada1c82b66450dd47</Sha>
+      <Sha>1b087e13d1755fbd6687bc4b2b1a926627a23365</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.PlatformAbstractions" Version="5.0.0-alpha1.19522.6">
+    <Dependency Name="Microsoft.NETCore.App.Runtime.win-x64" Version="5.0.0-alpha1.19523.2">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>57ce3c5fafe565a9b1f397cada1c82b66450dd47</Sha>
+      <Sha>1b087e13d1755fbd6687bc4b2b1a926627a23365</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.HostModel" Version="5.0.0-alpha1.19522.6">
+    <Dependency Name="Microsoft.DotNet.PlatformAbstractions" Version="5.0.0-alpha1.19523.2">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>57ce3c5fafe565a9b1f397cada1c82b66450dd47</Sha>
+      <Sha>1b087e13d1755fbd6687bc4b2b1a926627a23365</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="5.0.0-alpha1.19522.6">
+    <Dependency Name="Microsoft.NET.HostModel" Version="5.0.0-alpha1.19523.2">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>57ce3c5fafe565a9b1f397cada1c82b66450dd47</Sha>
+      <Sha>1b087e13d1755fbd6687bc4b2b1a926627a23365</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="5.0.0-alpha1.19522.6">
+    <Dependency Name="Microsoft.Extensions.DependencyModel" Version="5.0.0-alpha1.19523.2">
       <Uri>https://github.com/dotnet/core-setup</Uri>
-      <Sha>57ce3c5fafe565a9b1f397cada1c82b66450dd47</Sha>
+      <Sha>1b087e13d1755fbd6687bc4b2b1a926627a23365</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.NETCore.DotNetHostResolver" Version="5.0.0-alpha1.19523.2">
+      <Uri>https://github.com/dotnet/core-setup</Uri>
+      <Sha>1b087e13d1755fbd6687bc4b2b1a926627a23365</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Sdk" Version="5.0.100-alpha1.19501.2">
       <Uri>https://github.com/dotnet/sdk</Uri>
@@ -45,17 +49,17 @@
       <Uri>https://github.com/dotnet/roslyn</Uri>
       <Sha>3c865821f2864393a0ff7fe22c92ded6d51a546c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="5.0.0-alpha1.19522.2">
+    <Dependency Name="Microsoft.AspNetCore.DeveloperCertificates.XPlat" Version="5.0.0-alpha1.19522.13">
       <Uri>https://github.com/aspnet/AspNetCore</Uri>
-      <Sha>1189a2c294df55d7a67f1bc6ea74d74858f467bd</Sha>
+      <Sha>74360c7d97f9b55b94fecbd6e0598daf0c1b7cd1</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Sdk.Razor" Version="5.0.0-alpha1.19519.1">
       <Uri>https://github.com/aspnet/AspNetCore-Tooling</Uri>
       <Sha>9dd83077aa7dda45acea084a0dde6265393a12d6</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.WindowsDesktop.App" Version="5.0.0-alpha1.19522.3">
+    <Dependency Name="Microsoft.WindowsDesktop.App" Version="5.0.0-alpha1.19523.6">
       <Uri>https://github.com/dotnet/windowsdesktop</Uri>
-      <Sha>f3b299f3cd91a42c0c0285cf0709f23a74d13357</Sha>
+      <Sha>3ea8d593d98622c6728e5255b5503c13093f8fe1</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Sdk.WindowsDesktop" Version="5.0.0-alpha1.19462.16" CoherentParentDependency="Microsoft.WindowsDesktop.App">
       <Uri>https://github.com/dotnet/wpf</Uri>
@@ -69,29 +73,29 @@
       <Uri>https://github.com/microsoft/vstest</Uri>
       <Sha>32a75bd117876d8ad9c023cd0029df97412d1706</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk.Web" Version="5.0.100-alpha1.19522.2">
+    <Dependency Name="Microsoft.NET.Sdk.Web" Version="5.0.100-alpha1.19523.2">
       <Uri>https://github.com/aspnet/websdk</Uri>
-      <Sha>67228e1a9a8b400bccf8429c7840765ed2e49a48</Sha>
+      <Sha>30367e16177a4ecda3534c06e0449203c2f01e22</Sha>
     </Dependency>
     <Dependency Name="ILLink.Tasks" Version="0.1.6-prerelease.19380.1">
       <Uri>https://github.com/mono/linker</Uri>
       <Sha>18ff3f49475c3fc3fafa1d17161b1525eea182d8</Sha>
     </Dependency>
-    <Dependency Name="System.CodeDom" Version="5.0.0-alpha1.19521.4" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.CodeDom" Version="5.0.0-alpha1.19523.2" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>46299619e290936c495264162ede68354ced5b18</Sha>
+      <Sha>daadeef2eef255f86b301ded57996dda25618e90</Sha>
     </Dependency>
-    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="5.0.0-alpha1.19521.4" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.Security.Cryptography.ProtectedData" Version="5.0.0-alpha1.19523.2" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>46299619e290936c495264162ede68354ced5b18</Sha>
+      <Sha>daadeef2eef255f86b301ded57996dda25618e90</Sha>
     </Dependency>
-    <Dependency Name="System.Text.Encoding.CodePages" Version="5.0.0-alpha1.19521.4" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.Text.Encoding.CodePages" Version="5.0.0-alpha1.19523.2" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>46299619e290936c495264162ede68354ced5b18</Sha>
+      <Sha>daadeef2eef255f86b301ded57996dda25618e90</Sha>
     </Dependency>
-    <Dependency Name="System.Resources.Extensions" Version="5.0.0-alpha1.19521.4" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
+    <Dependency Name="System.Resources.Extensions" Version="5.0.0-alpha1.19523.2" CoherentParentDependency="Microsoft.NETCore.App.Runtime.win-x64">
       <Uri>https://github.com/dotnet/corefx</Uri>
-      <Sha>46299619e290936c495264162ede68354ced5b18</Sha>
+      <Sha>daadeef2eef255f86b301ded57996dda25618e90</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -22,7 +22,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/msbuild -->
-    <MicrosoftBuildPackageVersion>16.3.0-preview-19456-02</MicrosoftBuildPackageVersion>
+    <MicrosoftBuildPackageVersion>16.4.0-preview-19460-01</MicrosoftBuildPackageVersion>
     <MicrosoftBuildFrameworkPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildFrameworkPackageVersion>
     <MicrosoftBuildRuntimePackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildRuntimePackageVersion>
     <MicrosoftBuildLocalizationPackageVersion>$(MicrosoftBuildPackageVersion)</MicrosoftBuildLocalizationPackageVersion>
@@ -38,22 +38,22 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
-    <MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>5.0.0-alpha1.19427.5</MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>
+    <MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>5.0.0-alpha1.19522.2</MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore-Tooling -->
-    <MicrosoftNETSdkRazorPackageVersion>5.0.0-alpha1.19515.1</MicrosoftNETSdkRazorPackageVersion>
+    <MicrosoftNETSdkRazorPackageVersion>5.0.0-alpha1.19519.1</MicrosoftNETSdkRazorPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/websdk -->
-    <MicrosoftNETSdkWebPackageVersion>5.0.100-alpha1.19467.1</MicrosoftNETSdkWebPackageVersion>
+    <MicrosoftNETSdkWebPackageVersion>5.0.100-alpha1.19522.2</MicrosoftNETSdkWebPackageVersion>
     <MicrosoftNETSdkPublishPackageVersion>$(MicrosoftNETSdkWebPackageVersion)</MicrosoftNETSdkPublishPackageVersion>
     <MicrosoftNETSdkWebProjectSystemPackageVersion>$(MicrosoftNETSdkWebPackageVersion)</MicrosoftNETSdkWebProjectSystemPackageVersion>
     <MicrosoftNETSdkWorkerPackageVersion>$(MicrosoftNETSdkWebPackageVersion)</MicrosoftNETSdkWorkerPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/wpf -->
-    <MicrosoftNETSdkWindowsDesktopPackageVersion>5.0.0-alpha1.19462.16</MicrosoftNETSdkWindowsDesktopPackageVersion>
+    <MicrosoftNETSdkWindowsDesktopPackageVersion>5.0.0-alpha1.19522.10</MicrosoftNETSdkWindowsDesktopPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/templating -->
@@ -93,19 +93,19 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/corefx -->
-    <SystemCodeDomPackageVersion>5.0.0-alpha1.19517.14</SystemCodeDomPackageVersion>
-    <SystemTextEncodingCodePagesPackageVersion>5.0.0-alpha1.19517.14</SystemTextEncodingCodePagesPackageVersion>
-    <SystemSecurityCryptographyProtectedDataPackageVersion>5.0.0-alpha1.19517.14</SystemSecurityCryptographyProtectedDataPackageVersion>
+    <SystemCodeDomPackageVersion>5.0.0-alpha1.19521.4</SystemCodeDomPackageVersion>
+    <SystemTextEncodingCodePagesPackageVersion>5.0.0-alpha1.19521.4</SystemTextEncodingCodePagesPackageVersion>
+    <SystemSecurityCryptographyProtectedDataPackageVersion>5.0.0-alpha1.19521.4</SystemSecurityCryptographyProtectedDataPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/core-setup -->
-    <MicrosoftNETCoreAppRefPackageVersion>5.0.0-alpha1.19518.1</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>5.0.0-alpha1.19518.1</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
-    <MicrosoftNETCoreAppRuntimePackageVersion>$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</MicrosoftNETCoreAppRuntimePackageVersion>    
-    <MicrosoftDotNetPlatformAbstractionsPackageVersion>5.0.0-alpha1.19428.13</MicrosoftDotNetPlatformAbstractionsPackageVersion>
-    <MicrosoftExtensionsDependencyModelPackageVersion>5.0.0-alpha1.19428.13</MicrosoftExtensionsDependencyModelPackageVersion>
-    <MicrosoftNETCoreDotNetHostResolverPackageVersion>5.0.0-alpha1.19428.13</MicrosoftNETCoreDotNetHostResolverPackageVersion>
-    <MicrosoftNETHostModelVersion>5.0.0-alpha1.19428.13</MicrosoftNETHostModelVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>5.0.0-alpha1.19522.6</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>5.0.0-alpha1.19522.6</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftNETCoreAppRuntimePackageVersion>$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</MicrosoftNETCoreAppRuntimePackageVersion>
+    <MicrosoftDotNetPlatformAbstractionsPackageVersion>5.0.0-alpha1.19522.6</MicrosoftDotNetPlatformAbstractionsPackageVersion>
+    <MicrosoftExtensionsDependencyModelPackageVersion>5.0.0-alpha1.19522.6</MicrosoftExtensionsDependencyModelPackageVersion>
+    <MicrosoftNETCoreDotNetHostResolverPackageVersion>5.0.0-alpha1.19522.6</MicrosoftNETCoreDotNetHostResolverPackageVersion>
+    <MicrosoftNETHostModelVersion>5.0.0-alpha1.19522.6</MicrosoftNETHostModelVersion>
   </PropertyGroup>
   <PropertyGroup>
     <NewtonsoftJsonPackageVersion>11.0.1</NewtonsoftJsonPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -38,7 +38,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore -->
-    <MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>5.0.0-alpha1.19522.2</MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>
+    <MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>5.0.0-alpha1.19522.13</MicrosoftAspNetCoreDeveloperCertificatesXPlatPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/AspNetCore-Tooling -->
@@ -46,7 +46,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/aspnet/websdk -->
-    <MicrosoftNETSdkWebPackageVersion>5.0.100-alpha1.19522.2</MicrosoftNETSdkWebPackageVersion>
+    <MicrosoftNETSdkWebPackageVersion>5.0.100-alpha1.19523.2</MicrosoftNETSdkWebPackageVersion>
     <MicrosoftNETSdkPublishPackageVersion>$(MicrosoftNETSdkWebPackageVersion)</MicrosoftNETSdkPublishPackageVersion>
     <MicrosoftNETSdkWebProjectSystemPackageVersion>$(MicrosoftNETSdkWebPackageVersion)</MicrosoftNETSdkWebProjectSystemPackageVersion>
     <MicrosoftNETSdkWorkerPackageVersion>$(MicrosoftNETSdkWebPackageVersion)</MicrosoftNETSdkWorkerPackageVersion>
@@ -57,7 +57,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/templating -->
-    <MicrosoftTemplateEngineCliPackageVersion>5.0.0-alpha1.19463.4</MicrosoftTemplateEngineCliPackageVersion>
+    <MicrosoftTemplateEngineCliPackageVersion>5.0.0-alpha1.19516.1</MicrosoftTemplateEngineCliPackageVersion>
     <MicrosoftTemplateEngineAbstractionsPackageVersion>$(MicrosoftTemplateEngineCliPackageVersion)</MicrosoftTemplateEngineAbstractionsPackageVersion>
     <MicrosoftTemplateEngineCliLocalizationPackageVersion>$(MicrosoftTemplateEngineCliPackageVersion)</MicrosoftTemplateEngineCliLocalizationPackageVersion>
     <MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>$(MicrosoftTemplateEngineCliPackageVersion)</MicrosoftTemplateEngineOrchestratorRunnableProjectsPackageVersion>
@@ -93,20 +93,20 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/corefx -->
-    <SystemCodeDomPackageVersion>5.0.0-alpha1.19521.4</SystemCodeDomPackageVersion>
-    <SystemTextEncodingCodePagesPackageVersion>5.0.0-alpha1.19521.4</SystemTextEncodingCodePagesPackageVersion>
-    <SystemSecurityCryptographyProtectedDataPackageVersion>5.0.0-alpha1.19521.4</SystemSecurityCryptographyProtectedDataPackageVersion>
-    <SystemResourcesExtensionsPackageVersion>5.0.0-alpha1.19521.4</SystemResourcesExtensionsPackageVersion>
+    <SystemCodeDomPackageVersion>5.0.0-alpha1.19523.2</SystemCodeDomPackageVersion>
+    <SystemTextEncodingCodePagesPackageVersion>5.0.0-alpha1.19523.2</SystemTextEncodingCodePagesPackageVersion>
+    <SystemSecurityCryptographyProtectedDataPackageVersion>5.0.0-alpha1.19523.2</SystemSecurityCryptographyProtectedDataPackageVersion>
+    <SystemResourcesExtensionsPackageVersion>5.0.0-alpha1.19523.2</SystemResourcesExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/core-setup -->
-    <MicrosoftNETCoreAppRefPackageVersion>5.0.0-alpha1.19522.6</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>5.0.0-alpha1.19522.6</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>5.0.0-alpha1.19523.2</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETCoreAppRuntimewinx64PackageVersion>5.0.0-alpha1.19523.2</MicrosoftNETCoreAppRuntimewinx64PackageVersion>
     <MicrosoftNETCoreAppRuntimePackageVersion>$(MicrosoftNETCoreAppRuntimewinx64PackageVersion)</MicrosoftNETCoreAppRuntimePackageVersion>
-    <MicrosoftDotNetPlatformAbstractionsPackageVersion>5.0.0-alpha1.19522.6</MicrosoftDotNetPlatformAbstractionsPackageVersion>
-    <MicrosoftExtensionsDependencyModelPackageVersion>5.0.0-alpha1.19522.6</MicrosoftExtensionsDependencyModelPackageVersion>
-    <MicrosoftNETCoreDotNetHostResolverPackageVersion>5.0.0-alpha1.19522.6</MicrosoftNETCoreDotNetHostResolverPackageVersion>
-    <MicrosoftNETHostModelVersion>5.0.0-alpha1.19522.6</MicrosoftNETHostModelVersion>
+    <MicrosoftDotNetPlatformAbstractionsPackageVersion>5.0.0-alpha1.19523.2</MicrosoftDotNetPlatformAbstractionsPackageVersion>
+    <MicrosoftExtensionsDependencyModelPackageVersion>5.0.0-alpha1.19523.2</MicrosoftExtensionsDependencyModelPackageVersion>
+    <MicrosoftNETCoreDotNetHostResolverPackageVersion>5.0.0-alpha1.19523.2</MicrosoftNETCoreDotNetHostResolverPackageVersion>
+    <MicrosoftNETHostModelVersion>5.0.0-alpha1.19523.2</MicrosoftNETHostModelVersion>
   </PropertyGroup>
   <PropertyGroup>
     <NewtonsoftJsonPackageVersion>11.0.1</NewtonsoftJsonPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -96,6 +96,7 @@
     <SystemCodeDomPackageVersion>5.0.0-alpha1.19521.4</SystemCodeDomPackageVersion>
     <SystemTextEncodingCodePagesPackageVersion>5.0.0-alpha1.19521.4</SystemTextEncodingCodePagesPackageVersion>
     <SystemSecurityCryptographyProtectedDataPackageVersion>5.0.0-alpha1.19521.4</SystemSecurityCryptographyProtectedDataPackageVersion>
+    <SystemResourcesExtensionsPackageVersion>5.0.0-alpha1.19521.4</SystemResourcesExtensionsPackageVersion>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/dotnet/core-setup -->

--- a/global.json
+++ b/global.json
@@ -1,9 +1,12 @@
 {
+  "__comment": "There are currently some tests that are creating 3.0 projects due to lagging templates and the 3.0 runtime version in stage 0 is the 3.0 preview below.",
+  
   "tools": {
-    "dotnet": "3.0.100",
+    "dotnet": "5.0.100-alpha1-014915",
     "runtimes": {
       "dotnet": [
-        "$(MicrosoftNETCoreAppRuntimePackageVersion)"
+        "$(MicrosoftNETCoreAppRuntimePackageVersion)",
+        "3.0.0-rc1-19456-20"
       ]
     }
   },

--- a/src/dotnet/Telemetry/Telemetry.cs
+++ b/src/dotnet/Telemetry/Telemetry.cs
@@ -178,19 +178,16 @@ namespace Microsoft.DotNet.Cli.Telemetry
 
         private Dictionary<string, string> GetEventProperties(IDictionary<string, string> properties)
         {
+            var eventProperties = new Dictionary<string, string>(_commonProperties);
             if (properties != null)
             {
-                var eventProperties = new Dictionary<string, string>(_commonProperties);
                 foreach (KeyValuePair<string, string> property in properties)
                 {
                     eventProperties[property.Key] = property.Value;
                 }
-                return eventProperties;
             }
-            else
-            {
-                return _commonProperties;
-            }
+
+            return eventProperties;
         }
     }
 }

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="System.CodeDom" Version="$(SystemCodeDomPackageVersion)" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="$(SystemTextEncodingCodePagesPackageVersion)" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="$(SystemSecurityCryptographyProtectedDataPackageVersion)" />
+    <PackageReference Include="System.Resources.Extensions" Version="$(SystemResourcesExtensionsPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tool_msbuild/tool_msbuild.csproj
+++ b/src/tool_msbuild/tool_msbuild.csproj
@@ -9,5 +9,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Runtime" Version="$(MicrosoftBuildRuntimePackageVersion)" />
     <PackageReference Include="Microsoft.Build.Localization" Version="$(MicrosoftBuildLocalizationPackageVersion)" />
+    <PackageReference Include="System.Resources.Extensions" Version="$(SystemResourcesExtensionsPackageVersion)" />
   </ItemGroup>
 </Project>

--- a/test/Microsoft.DotNet.Cli.Utils.Tests/Microsoft.DotNet.Cli.Utils.Tests.csproj
+++ b/test/Microsoft.DotNet.Cli.Utils.Tests/Microsoft.DotNet.Cli.Utils.Tests.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="$(MicrosoftDotNetPlatformAbstractionsPackageVersion)" />
     <PackageReference Include="Microsoft.Build.Runtime" Version="$(MicrosoftBuildRuntimePackageVersion)" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
+    <PackageReference Include="System.Resources.Extensions" Version="$(SystemResourcesExtensionsPackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/test/dotnet-pack.Tests/PackTests.cs
+++ b/test/dotnet-pack.Tests/PackTests.cs
@@ -159,7 +159,7 @@ namespace Microsoft.DotNet.Pack.Tests
 
         [Theory]
         [InlineData("TestAppSimple")]
-        [InlineData("FSharpTestAppSimple")]
+        [InlineData("FSharpTestAppSimple", Skip = "https://github.com/dotnet/coreclr/issues/27275")]
         public void PackWorksWithLocalProject(string projectName)
         {
             var testInstance = TestAssets.Get(projectName)

--- a/test/dotnet-store.Tests/GivenDotnetStoresAndPublishesProjects.cs
+++ b/test/dotnet-store.Tests/GivenDotnetStoresAndPublishesProjects.cs
@@ -102,7 +102,7 @@ namespace Microsoft.DotNet.Cli.Publish.Tests
                 .Should().Fail()
                 .And.HaveStdErrContaining($"Error:{Environment.NewLine}" +
                     $"  An assembly specified in the application dependencies manifest (NuGetConfigDependentProject.deps.json) was not found:{Environment.NewLine}" +
-                    $"    package: 'NuGet.Configuration', version: '4.3.0-preview3-4146'{Environment.NewLine}" +
+                    $"    package: 'NuGet.Configuration', version: '4.3.0'{Environment.NewLine}" +
                     "    path: 'lib/netstandard1.3/NuGet.Configuration.dll'");
         }
 


### PR DESCRIPTION
Several issues:

1. There were some mistakes in Version.Details.xml, cli was still in there, some packages were missing, leading to incomplete dependency update prs. Fix those and update to latest from .NET Core 5 Dev channel.
2. Taking latest meant we need to target netcoreapp5.0, so do that.
3. Port a fix for flaky telemetry test failure from dotnet/cli 3.x branch
4. Clean up nuget.config to minimize feeds

This is holding up dependency flow so a quick review would be good.

