### PR TITLE
Clarify restore messages

### DIFF
--- a/src/dotnet/commands/dotnet-tool/restore/LocalizableStrings.resx
+++ b/src/dotnet/commands/dotnet-tool/restore/LocalizableStrings.resx
@@ -171,13 +171,13 @@
     <value>Tool '{0}' (version '{1}') was restored. Available commands: {2}</value>
   </data>
   <data name="RestorePartiallyFailed" xml:space="preserve">
-    <value>Restore partially failed.</value>
+    <value>Tools restore partially failed.</value>
   </data>
   <data name="RestoreFailed" xml:space="preserve">
-    <value>Restore failed.</value>
+    <value>Tools restore failed.</value>
   </data>
   <data name="LocalToolsRestoreWasSuccessful" xml:space="preserve">
-    <value>Restore was successful.</value>
+    <value>Tools restore was successful.</value>
   </data>
   <data name="PackagesCommandNameCollisionForOnePackage" xml:space="preserve">
     <value>A command "{0}" in package "{1}"</value>

--- a/src/dotnet/commands/dotnet-tool/restore/ToolRestoreCommand.cs
+++ b/src/dotnet/commands/dotnet-tool/restore/ToolRestoreCommand.cs
@@ -197,7 +197,6 @@ namespace Microsoft.DotNet.Tools.Tool.Restore
             {
                 _reporter.WriteLine(string.Join(Environment.NewLine,
                     toolRestoreResults.Where(r => r.IsSuccess).Select(r => r.Message)));
-                _reporter.WriteLine();
                 _reporter.WriteLine(LocalizableStrings.LocalToolsRestoreWasSuccessful.Green());
 
                 return 0;

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.cs.xlf
@@ -70,8 +70,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestoreFailed">
-        <source>Restore failed.</source>
-        <target state="translated">Obnovení nebylo úspěšné.</target>
+        <source>Tools restore failed.</source>
+        <target state="needs-review-translation">Obnovení nebylo úspěšné.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandsMismatch">
@@ -95,8 +95,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LocalToolsRestoreWasSuccessful">
-        <source>Restore was successful.</source>
-        <target state="translated">Obnovení proběhlo úspěšně.</target>
+        <source>Tools restore was successful.</source>
+        <target state="needs-review-translation">Obnovení proběhlo úspěšně.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagesCommandNameCollisionConclusion">
@@ -112,8 +112,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestorePartiallyFailed">
-        <source>Restore partially failed.</source>
-        <target state="translated">Obnovení bylo částečně neúspěšné.</target>
+        <source>Tools restore partially failed.</source>
+        <target state="needs-review-translation">Obnovení bylo částečně neúspěšné.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.de.xlf
@@ -70,8 +70,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestoreFailed">
-        <source>Restore failed.</source>
-        <target state="translated">Fehler bei der Wiederherstellung.</target>
+        <source>Tools restore failed.</source>
+        <target state="needs-review-translation">Fehler bei der Wiederherstellung.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandsMismatch">
@@ -95,8 +95,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LocalToolsRestoreWasSuccessful">
-        <source>Restore was successful.</source>
-        <target state="translated">Die Wiederherstellung war erfolgreich.</target>
+        <source>Tools restore was successful.</source>
+        <target state="needs-review-translation">Die Wiederherstellung war erfolgreich.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagesCommandNameCollisionConclusion">
@@ -112,8 +112,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestorePartiallyFailed">
-        <source>Restore partially failed.</source>
-        <target state="translated">Die Wiederherstellung war nur teilweise möglich.</target>
+        <source>Tools restore partially failed.</source>
+        <target state="needs-review-translation">Die Wiederherstellung war nur teilweise möglich.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.es.xlf
@@ -70,8 +70,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestoreFailed">
-        <source>Restore failed.</source>
-        <target state="translated">No se pudo llevar a cabo la restauración.</target>
+        <source>Tools restore failed.</source>
+        <target state="needs-review-translation">No se pudo llevar a cabo la restauración.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandsMismatch">
@@ -95,8 +95,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LocalToolsRestoreWasSuccessful">
-        <source>Restore was successful.</source>
-        <target state="translated">Restauración realizada correctamente.</target>
+        <source>Tools restore was successful.</source>
+        <target state="needs-review-translation">Restauración realizada correctamente.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagesCommandNameCollisionConclusion">
@@ -112,8 +112,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestorePartiallyFailed">
-        <source>Restore partially failed.</source>
-        <target state="translated">Error parcial de restauración.</target>
+        <source>Tools restore partially failed.</source>
+        <target state="needs-review-translation">Error parcial de restauración.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.fr.xlf
@@ -70,8 +70,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestoreFailed">
-        <source>Restore failed.</source>
-        <target state="translated">La restauration a échoué.</target>
+        <source>Tools restore failed.</source>
+        <target state="needs-review-translation">La restauration a échoué.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandsMismatch">
@@ -95,8 +95,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LocalToolsRestoreWasSuccessful">
-        <source>Restore was successful.</source>
-        <target state="translated">La restauration a réussi.</target>
+        <source>Tools restore was successful.</source>
+        <target state="needs-review-translation">La restauration a réussi.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagesCommandNameCollisionConclusion">
@@ -112,8 +112,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestorePartiallyFailed">
-        <source>Restore partially failed.</source>
-        <target state="translated">Échec partiel de la restauration.</target>
+        <source>Tools restore partially failed.</source>
+        <target state="needs-review-translation">Échec partiel de la restauration.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.it.xlf
@@ -70,8 +70,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestoreFailed">
-        <source>Restore failed.</source>
-        <target state="translated">Ripristino non riuscito.</target>
+        <source>Tools restore failed.</source>
+        <target state="needs-review-translation">Ripristino non riuscito.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandsMismatch">
@@ -95,8 +95,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LocalToolsRestoreWasSuccessful">
-        <source>Restore was successful.</source>
-        <target state="translated">Il ripristino è riuscito.</target>
+        <source>Tools restore was successful.</source>
+        <target state="needs-review-translation">Il ripristino è riuscito.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagesCommandNameCollisionConclusion">
@@ -112,8 +112,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestorePartiallyFailed">
-        <source>Restore partially failed.</source>
-        <target state="translated">Il ripristino non è riuscito parzialmente.</target>
+        <source>Tools restore partially failed.</source>
+        <target state="needs-review-translation">Il ripristino non è riuscito parzialmente.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.ja.xlf
@@ -70,8 +70,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestoreFailed">
-        <source>Restore failed.</source>
-        <target state="translated">復元できませんでした。</target>
+        <source>Tools restore failed.</source>
+        <target state="needs-review-translation">復元できませんでした。</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandsMismatch">
@@ -95,8 +95,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LocalToolsRestoreWasSuccessful">
-        <source>Restore was successful.</source>
-        <target state="translated">正常に復元されました。</target>
+        <source>Tools restore was successful.</source>
+        <target state="needs-review-translation">正常に復元されました。</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagesCommandNameCollisionConclusion">
@@ -112,8 +112,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestorePartiallyFailed">
-        <source>Restore partially failed.</source>
-        <target state="translated">復元が部分的に失敗しました。</target>
+        <source>Tools restore partially failed.</source>
+        <target state="needs-review-translation">復元が部分的に失敗しました。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.ko.xlf
@@ -70,8 +70,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestoreFailed">
-        <source>Restore failed.</source>
-        <target state="translated">복원하지 못했습니다.</target>
+        <source>Tools restore failed.</source>
+        <target state="needs-review-translation">복원하지 못했습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandsMismatch">
@@ -95,8 +95,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LocalToolsRestoreWasSuccessful">
-        <source>Restore was successful.</source>
-        <target state="translated">복원했습니다.</target>
+        <source>Tools restore was successful.</source>
+        <target state="needs-review-translation">복원했습니다.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagesCommandNameCollisionConclusion">
@@ -112,8 +112,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestorePartiallyFailed">
-        <source>Restore partially failed.</source>
-        <target state="translated">부분적으로 복원하지 못했습니다.</target>
+        <source>Tools restore partially failed.</source>
+        <target state="needs-review-translation">부분적으로 복원하지 못했습니다.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.pl.xlf
@@ -70,8 +70,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestoreFailed">
-        <source>Restore failed.</source>
-        <target state="translated">Błąd przywracania.</target>
+        <source>Tools restore failed.</source>
+        <target state="needs-review-translation">Błąd przywracania.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandsMismatch">
@@ -95,8 +95,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LocalToolsRestoreWasSuccessful">
-        <source>Restore was successful.</source>
-        <target state="translated">Przywracanie zakończyło się pomyślnie.</target>
+        <source>Tools restore was successful.</source>
+        <target state="needs-review-translation">Przywracanie zakończyło się pomyślnie.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagesCommandNameCollisionConclusion">
@@ -112,8 +112,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestorePartiallyFailed">
-        <source>Restore partially failed.</source>
-        <target state="translated">Przywracanie częściowo nie powiodło się.</target>
+        <source>Tools restore partially failed.</source>
+        <target state="needs-review-translation">Przywracanie częściowo nie powiodło się.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.pt-BR.xlf
@@ -70,8 +70,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestoreFailed">
-        <source>Restore failed.</source>
-        <target state="translated">Falha na restauração.</target>
+        <source>Tools restore failed.</source>
+        <target state="needs-review-translation">Falha na restauração.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandsMismatch">
@@ -95,8 +95,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LocalToolsRestoreWasSuccessful">
-        <source>Restore was successful.</source>
-        <target state="translated">A restauração foi bem-sucedida.</target>
+        <source>Tools restore was successful.</source>
+        <target state="needs-review-translation">A restauração foi bem-sucedida.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagesCommandNameCollisionConclusion">
@@ -112,8 +112,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestorePartiallyFailed">
-        <source>Restore partially failed.</source>
-        <target state="translated">Falha parcial na restauração.</target>
+        <source>Tools restore partially failed.</source>
+        <target state="needs-review-translation">Falha parcial na restauração.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.ru.xlf
@@ -70,8 +70,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestoreFailed">
-        <source>Restore failed.</source>
-        <target state="translated">Сбой восстановления.</target>
+        <source>Tools restore failed.</source>
+        <target state="needs-review-translation">Сбой восстановления.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandsMismatch">
@@ -95,8 +95,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LocalToolsRestoreWasSuccessful">
-        <source>Restore was successful.</source>
-        <target state="translated">Восстановление выполнено успешно.</target>
+        <source>Tools restore was successful.</source>
+        <target state="needs-review-translation">Восстановление выполнено успешно.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagesCommandNameCollisionConclusion">
@@ -112,8 +112,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestorePartiallyFailed">
-        <source>Restore partially failed.</source>
-        <target state="translated">Восстановление частично не выполнено.</target>
+        <source>Tools restore partially failed.</source>
+        <target state="needs-review-translation">Восстановление частично не выполнено.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.tr.xlf
@@ -70,8 +70,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestoreFailed">
-        <source>Restore failed.</source>
-        <target state="translated">Geri yükleme başarısız oldu.</target>
+        <source>Tools restore failed.</source>
+        <target state="needs-review-translation">Geri yükleme başarısız oldu.</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandsMismatch">
@@ -95,8 +95,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LocalToolsRestoreWasSuccessful">
-        <source>Restore was successful.</source>
-        <target state="translated">Geri yükleme başarılı oldu.</target>
+        <source>Tools restore was successful.</source>
+        <target state="needs-review-translation">Geri yükleme başarılı oldu.</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagesCommandNameCollisionConclusion">
@@ -112,8 +112,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestorePartiallyFailed">
-        <source>Restore partially failed.</source>
-        <target state="translated">Geri yükleme kısmen başarısız oldu.</target>
+        <source>Tools restore partially failed.</source>
+        <target state="needs-review-translation">Geri yükleme kısmen başarısız oldu.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.zh-Hans.xlf
@@ -70,8 +70,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestoreFailed">
-        <source>Restore failed.</source>
-        <target state="translated">还原失败。</target>
+        <source>Tools restore failed.</source>
+        <target state="needs-review-translation">还原失败。</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandsMismatch">
@@ -95,8 +95,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LocalToolsRestoreWasSuccessful">
-        <source>Restore was successful.</source>
-        <target state="translated">还原成功。</target>
+        <source>Tools restore was successful.</source>
+        <target state="needs-review-translation">还原成功。</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagesCommandNameCollisionConclusion">
@@ -112,8 +112,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestorePartiallyFailed">
-        <source>Restore partially failed.</source>
-        <target state="translated">还原部分失败。</target>
+        <source>Tools restore partially failed.</source>
+        <target state="needs-review-translation">还原部分失败。</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet/commands/dotnet-tool/restore/xlf/LocalizableStrings.zh-Hant.xlf
@@ -70,8 +70,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestoreFailed">
-        <source>Restore failed.</source>
-        <target state="translated">還原失敗。</target>
+        <source>Tools restore failed.</source>
+        <target state="needs-review-translation">還原失敗。</target>
         <note />
       </trans-unit>
       <trans-unit id="CommandsMismatch">
@@ -95,8 +95,8 @@
         <note />
       </trans-unit>
       <trans-unit id="LocalToolsRestoreWasSuccessful">
-        <source>Restore was successful.</source>
-        <target state="translated">還原已成功。</target>
+        <source>Tools restore was successful.</source>
+        <target state="needs-review-translation">還原已成功。</target>
         <note />
       </trans-unit>
       <trans-unit id="PackagesCommandNameCollisionConclusion">
@@ -112,8 +112,8 @@
         <note />
       </trans-unit>
       <trans-unit id="RestorePartiallyFailed">
-        <source>Restore partially failed.</source>
-        <target state="translated">還原部分失敗。</target>
+        <source>Tools restore partially failed.</source>
+        <target state="needs-review-translation">還原部分失敗。</target>
         <note />
       </trans-unit>
     </body>


### PR DESCRIPTION
In the build of CoreCLR, is this console output:
```
    Tool 'coverlet.console' (version '1.6.0') was restored. Available commands: coverlet
    Tool 'dotnet-reportgenerator-globaltool' (version '4.3.6') was restored. Available commands: reportgenerator

    Restore was successful.
    Restore completed in 36.02 ms for C:\Users\danmose\.nuget\packages\microsoft.dotnet.arcade.sdk\5.0.0-beta.19617.1\tools\Tools.proj.
    Restore completed in 11.14 ms for C:\git\runtime\src\coreclr\src\.nuget\Microsoft.NETCore.TestHost\Microsoft.NETCore.TestHost.builds.
```
It was not clear that "restore was successful" relates to the tools being restored above, rather than relating to the subsequent restore of various projects.

This suggested change makes it clearer that this comes from tools restore. I also removed the extra blank line. Now it looks like

```
    Tool 'coverlet.console' (version '1.6.0') was restored. Available commands: coverlet
    Tool 'dotnet-reportgenerator-globaltool' (version '4.3.6') was restored. Available commands: reportgenerator
    Tools restore was successful.
    Restore completed in 36.02 ms for C:\Users\danmose\.nuget\packages\microsoft.dotnet.arcade.sdk\5.0.0-beta.19617.1\tools\Tools.proj.
    Restore completed in 11.14 ms for C:\git\runtime\src\coreclr\src\.nuget\Microsoft.NETCore.TestHost\Microsoft.NETCore.TestHost.builds.
```
