### PR TITLE
Improve zsh completion script to allow filename selection

### DIFF
--- a/scripts/register-completions.zsh
+++ b/scripts/register-completions.zsh
@@ -4,7 +4,15 @@ _dotnet_zsh_complete()
 {
   local completions=("$(dotnet complete "$words")")
 
-  reply=( "${(ps:\n:)completions}" )
+  # If the completion list is empty, just continue with filename selection
+  if [ -z "$completions" ]
+  then
+    _arguments '*::arguments: _normal'
+    return
+  fi
+
+  # This is not a variable assigment, don't remove spaces!
+  _values = "${(ps:\n:)completions}"
 }
 
-compctl -K _dotnet_zsh_complete dotnet
+compdef _dotnet_zsh_complete dotnet


### PR DESCRIPTION
Stuff done:
- The script now allows filename selection if nothing valid is returned from `dotnet complete` command
- Use `compdef` instead of `compctl`