### PR TITLE
Suppress msb4181 from vstest

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -61,7 +61,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <!-- Dependencies from https://github.com/Microsoft/vstest -->
-    <MicrosoftNETTestSdkPackageVersion>16.7.0-release-20200703-01</MicrosoftNETTestSdkPackageVersion>
+    <MicrosoftNETTestSdkPackageVersion>16.7.1-release-20201002-01</MicrosoftNETTestSdkPackageVersion>
     <MicrosoftTestPlatformCLIPackageVersion>$(MicrosoftNETTestSdkPackageVersion)</MicrosoftTestPlatformCLIPackageVersion>
     <MicrosoftTestPlatformBuildPackageVersion>$(MicrosoftNETTestSdkPackageVersion)</MicrosoftTestPlatformBuildPackageVersion>
   </PropertyGroup>


### PR DESCRIPTION
## Description

Set AllowFailureWithoutError to prevent the error MSB4181 from being output.

MSB4181: The "Microsoft.TestPlatform.Build.Tasks.VSTestTask" task returned false but did not log an error.

This error is caused by VSTest outputting errors directly to the screen instead of using MSBuild, and is blocking some builds from finishing. The same fix was done in net5.0.

There is no workaround, other than sticking with 3.1.302 SDK.

Those are the changes included in the update: 

https://github.com/microsoft/vstest/commit/4f345e9718e6a158adcc88675634c4f209a0c537
https://github.com/microsoft/vstest/commit/d8b591209204b2b947c495086c51a39d22c3bc14

The option is set to "false" because the version of MSBuild that is being used has the option implemented backwards. This issue was reported to MSBuild and will be fixed in 16.9.

## Customer Impact

Anyone who updated their 3.1 SDK from "3.1.302" to a newer version is impacted by this. Any failing test will make the VSTest MSBuild task fail and the build will fail with a confusing message. This makes the CI failures harder to diagnose, because the first error that you see is the MSBuild error, instead of the "x tests failed" error.

## Regression?

There was a change of behavior in MSBuild https://github.com/dotnet/msbuild/blob/ca44138662e3aa90eb9305dd31d906ef02e962cb/src/Build/BackEnd/Components/RequestBuilder/TaskBuilder.cs#L940-L958 that started showing this error for all tasks that return false but write their errors to screen in non standard way. VSTest is one of them, we write directly to screen because we want to have colors in our output to easily distinguish passed and failed tests.

## Risk (see taxonomy)

Very low. The change is limited to dotnet test. Tests can finish running with or without this change in place. Only the reporting of failed test results is affected.

## Link the PR to the original issue and/or the PR to master.
Fix https://github.com/dotnet/sdk/issues/13431

## Packaging impact? (if a libraries change)
I am not aware of any.
