### PR TITLE
[release/3.1.4xx] Re-enable SDL validation

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -149,7 +149,7 @@ stages:
       # This repo doesn't produce any signed packages.
       enableSigningValidation: false
       SDLValidationParameters:
-        enable: false
+        enable: true
         params: ' -SourceToolsList @("policheck","credscan")
         -TsaInstanceURL $(_TsaInstanceURL)
         -TsaProjectName $(_TsaProjectName)


### PR DESCRIPTION
We can re-enable this now that we've gotten an arcade update