### PR TITLE
Use -Svc pool provider in any release/ branch

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -128,7 +128,7 @@ stages:
           - Windows_NT
         pool:
           ${{ if eq(variables['System.TeamProject'], 'public') }}:
-            name: NetCore-Public
+            name: NetCore-Svc-Public
             demands: ImageOverride -equals windows.VS2019.amd64.Open
           ${{ if eq(variables['System.TeamProject'], 'internal') }}:
             name: NetCore1ESPool-Internal


### PR DESCRIPTION
Noted because this build ran, but a similar change should be made in any other active release branches.